### PR TITLE
Added support for YUV422

### DIFF
--- a/lib/libde265.js
+++ b/lib/libde265.js
@@ -10916,7 +10916,7 @@ var WorkerConverter = function() {
         }
         var blob = new Blob([
             "(function() {\n",
-            _do_convert_yuv420.toString() + ";\n",
+            _do_convert_yuv.toString() + ";\n",
             _do_convert_yuv2rgb.toString() + ";\n",
             worker_func_data + ";\n",
             worker_func_name + "();\n",
@@ -11114,7 +11114,7 @@ Decoder.prototype.decode = function(callback) {
     return;
 };
 
-function _do_convert_yuv420(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu, bppv, dest) {
+function _do_convert_yuv(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu, bppv, dest, logRowsUVStride) {
     var yval;
     var uval;
     var vval;
@@ -11150,8 +11150,8 @@ function _do_convert_yuv420(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu
             xpos = 0;
             ypos++;
             yoffset += stridey;
-            uoffset = ((ypos >> 1) * strideu);
-            voffset = ((ypos >> 1) * stridev);
+            uoffset = ((ypos >> logRowsUVStride) * strideu);
+            voffset = ((ypos >> logRowsUVStride) * stridev);
         }
     }
 }
@@ -11162,22 +11162,20 @@ function _do_convert_yuv2rgb(chroma, y, u, v, w, h, stridey, strideu, stridev, b
     }
     // NOTE: we can't use libde265 constants here as the function can also be
     // run inside the Worker where "libde265" is not available.
+    if (bppy !== 8 || bppu !== 8 || bppv !== 8) {
+        // TODO(fancycode): implement me
+        console.log("Chroma format not implemented yet", chroma, bppy, bppu, bppv);
+    }
     switch (chroma) {
     case 0:  /* libde265.de265_chroma_mono */
         // TODO(fancycode): implement me
         console.log("Chroma format not implemented yet", chroma, bppy, bppu, bppv);
         break;
     case 1:  /* libde265.de265_chroma_420 */
-        if (bppy !== 8 || bppu !== 8 || bppv !== 8) {
-            // TODO(fancycode): implement me
-            console.log("Chroma format not implemented yet", chroma, bppy, bppu, bppv);
-        } else {
-            _do_convert_yuv420(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu, bppv, dest);
-        }
+        _do_convert_yuv(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu, bppv, dest, 1);
         break;
     case 2:  /* libde265.de265_chroma_422 */
-        // TODO(fancycode): implement me
-        console.log("Chroma format not implemented yet", chroma, bppy, bppu, bppv);
+        _do_convert_yuv(y, u, v, w, h, stridey, strideu, stridev, bppy, bppu, bppv, dest, 0);
         break;
     case 3:  /* libde265.de265_chroma_444 */
         // TODO(fancycode): implement me


### PR DESCRIPTION
Minor change in __do_convert_yuv420 can support yuv422 pixel format.

Added a `logRowsUVStride` parameter which determines the number of rows in output image corresponding to one row in `U` and `V` input.

We then set `uoffset` and `voffset` depending on this parameter:
```js
uoffset = ((ypos >> logRowsUVStride) * strideu);
voffset = ((ypos >> logRowsUVStride) * stridev);
```

Tested it with ffmpeg generated YUV422 HEVC video.